### PR TITLE
Add GitHub Action Workflows

### DIFF
--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -1,0 +1,22 @@
+name: Auto Delete Branch on Dev Merge
+
+on:
+  pull_request: 
+    types: 
+      - closed
+
+jobs:
+  delete_branch:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'development' &&
+      github.event.pull_request.head.ref != 'development' &&
+      github.event.pull_request.head.ref != 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete source branch
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,16 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  enforce-development-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        if: github.event.pull_request.head.ref != 'development'
+        run: |
+          echo "Error: Only PRs from 'development' branch are allowed to merge into 'main'."
+          exit 1


### PR DESCRIPTION
Add GitHub action workflows to:
* Allow only 'development' branch to raise a PR towards 'main' branch.
* Automatically delete a branch after it's PR has been merged with 'development' branch.